### PR TITLE
Update and refine the Heroku deployment guide

### DIFF
--- a/server/guides/deploying/heroku.md
+++ b/server/guides/deploying/heroku.md
@@ -3,99 +3,104 @@ layout: page
 title: Deploying to Heroku
 ---
 
-## What is Heroku
+Heroku is a popular all-in-one hosting solution.
 
-Heroku is a popular all in one hosting solution, you can find more at heroku.com
+For your Heroku application, you only need to select a virtual operating system ([stack](#stack-selection)) and preinstalled software packages ([buildpack](#buildback-selection)). After installing Heroku's CLI tools, you can use standard git commands to push your code to Heroku, where it will be built from source and deployed.
 
-## Signing Up
+You can learn more at [heroku.com](https://heroku.com/).
 
-You'll need a heroku account, if you don't have one, please sign up here: [https://signup.heroku.com/](https://signup.heroku.com/)
+## Sign-Up
 
-## Installing CLI
+You'll need a Heroku account. If you don't have one, please sign up [here](https://signup.heroku.com/).
 
-Make sure that you've installed the heroku cli tool.
+## CLI Setup
 
-### HomeBrew
+Make sure that you've installed the Heroku CLI tools.
+
+### Homebrew Installation
 
 ```bash
-brew install heroku/brew/heroku
+brew tap heroku/brew && brew install heroku
 ```
 
 ### Other Install Options
 
-See alternative install options here: [https://devcenter.heroku.com/articles/heroku-cli#download-and-install](https://devcenter.heroku.com/articles/heroku-cli#download-and-install).
+See alternative install options [here](https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli).
 
-### Logging in
+### Login
 
-Once you've installed the CLI, login with the following:
+Once you've installed the CLI, log in with the following command:
 
 ```bash
 heroku login
 ```
 
-### Create an application
+…and follow the prompts.
 
-Visit dashboard.heroku.com to access your account, and create a new application from the drop down in the upper right hand corner. Heroku will ask a few questions such as region and application name, just follow their prompts.
+## Application Setup
 
-### Project
+Visit [the Heroku dashboard](https://dashboard.heroku.com/) to access your account, and create a new application from the dropdown in the upper right hand corner. Heroku will ask a few questions such as region and application name, just follow their prompts.
 
-Today we're going to be hosting Swift NIO's example http server, you can apply these concepts to your own project. Let's start by cloning NIO
+### Example Project Creation
+
+For this guide, we're going to be hosting Swift NIO's example HTTP server – you can apply these concepts to your own project. Let's start by cloning NIO:
 
 ```bash
-
 git clone https://github.com/apple/swift-nio
 ```
 
-Make sure to make our newly cloned directory the working directory
+Make sure to make our newly cloned directory the working directory:
 
 
 ```bash
 cd swift-nio
 ```
 
-By default, Heroku deploys the **master** branch. Always make sure all changes are checked into this branch before pushing.
+By default, Heroku deploys the **main** branch. Always make sure all changes are checked into this branch before pushing.
 
-#### Connect with Heroku
+#### Connecting to Heroku
 
-Connect your app with Heroku (replace with your app's name).
-
-```bash
-$ heroku git:remote -a your-apps-name-here
-```
-
-### Set Stack
-
-As of 13 September 2018, Heroku’s default stack is Heroku 18, we need it to be 16 for swift projects.
+Connect your app with Heroku (*replace with your app's name*):
 
 ```bash
-heroku stack:set heroku-16 -a your-apps-name-here
+heroku git:remote -a your-apps-name-here
 ```
 
-### Set Buildpack
+### Stack Selection
 
-Set the buildpack to teach Heroku how to deal with swift, the vapor-communnity buildpack is a good buildpack for *any swift project*. It doesn't install vapor, and it doesn't have any vapor specific setup.
+As of December 2023, Heroku’s default stack is Heroku 22:
 
+```bash
+heroku stack:set heroku-22 -a your-apps-name-here
+```
+
+Currently available stacks are listed [here](https://devcenter.heroku.com/articles/stack#default-stack).
+
+### Buildpack Selection
+
+Set the buildpack to teach Heroku how to deal with Swift. The [Vapor Community buildpack](https://github.com/vapor-community/heroku-buildpack) is a good buildpack for *any* Swift project. It doesn't install Vapor, and it doesn't have any Vapor-specific setup.
 
 ```bash
 heroku buildpacks:set vapor/vapor
 ```
 
-### Swift version file
+### Swift Version Selection
 
-The buildpack we added looks for a **.swift-version** file to know which version of swift to use.
+The buildpack we added looks for a **.swift-version** file in the project root directory to know which version of Swift to use.
 
 ```bash
-echo "5.2" > .swift-version
+echo "5.9" > .swift-version
 ```
 
-This creates **.swift-version** with `5.2` as its contents.
+This creates **.swift-version** with `5.9` as its contents.
 
+When new versions of Swift are released, the buildpack needs to be updated before you can adopt the latest version.
 
-### Procfile
+### Procfile Creation
 
-Heroku uses the **Procfile** to know how to run your app. This includes the executable name and any arguments necessary. You'll see `$PORT` below, this allows heroku to assign a specific port when it launches the app.
+Heroku uses a **Procfile** to know how to launch and run your app. This includes the executable name and any arguments necessary. You'll see `$PORT` below, this allows Heroku to assign a specific port when it launches the app.
 
-```
+```bash
 web: NIOHTTP1Server 0.0.0.0 $PORT
 ```
 
@@ -106,14 +111,24 @@ You can use this command in terminal to set the file
 echo "web: NIOHTTP1Server 0.0.0.0 $PORT" > Procfile
 ```
 
-### Commit changes
+The contents of this file may vary depending on your server framework. For Vapor apps, the default Procfile content is the follwowing:
 
-We have now added the `.swift-version` file, and the `Procfile`, make sure these are committed into master or Heroku will not find them.
+```bash
+web: Run serve --env production --hostname 0.0.0.0 --port $PORT
+```
 
-### Deploying to Heroku
+### Wrap-Up
 
-You're ready to deploy, run this from the terminal. It may take a while to build, this is normal.
+Now that we have added the `.swift-version` and `Procfile` files, make sure these are committed on `main` to be included in your deployment.
 
-```none
+## Deployment to Heroku
+
+When you're ready to deploy, run this from the terminal:
+
+```bash
 git push heroku master
 ```
+
+This will take significantly longer than regular git operations as Heroku will build your project incl. all dependencies from scratch, verify and deploy it.
+
+More information can be found on [here](https://devcenter.heroku.com/articles/git#deploying-code).


### PR DESCRIPTION
Change summary:
- update to latest Heroku stack
- change default branch name to `main`
- consistent formatting & capitalization
- additional links and high-level overview